### PR TITLE
Add possibility to extend query from user model while finding user by credentials

### DIFF
--- a/classes/AuthHelperManager.php
+++ b/classes/AuthHelperManager.php
@@ -215,6 +215,9 @@ class AuthHelperManager extends AuthManager
                 $arHashedCredentials = array_merge($arHashedCredentials, [$sCredential => $sValue]);
             } else {
                 $obQuery = $obQuery->where($sCredential, '=', $sValue);
+                if ($obModel->methodExists('scopeExtendLoginQuery')) {
+                    $obQuery = $obQuery->extendLoginQuery($sCredential, $sValue);
+                }
             }
         }
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -18,3 +18,5 @@
     - 'Adds flag to avoid auto logging in newly registered users. Fixes'
 1.4.0:
     - 'Refactoring UserItem class. Add annotations for integration with "Orders for Shopaholic" plugin. Refactoring fields and columns files. Requires Toolbox plugin version 1.10.0 and later.'
+1.4.1:
+    - 'Add possibility to extend query from user model while finding user by credentials'


### PR DESCRIPTION
Use case:

In login form I want to have login field that can accept email OR username. To acheive this I need to have ability to create more complex queries to find user's record.

In my plugin I want to do:

        User::extend(function ($model) {
            $model->addDynamicMethod('scopeExtendLoginQuery', function ($q, $credential, $val) use ($model) {
                if ($credential == 'email') {
                    $q = $q->orWhere('login', $val);
                }

                return $q;
            });
        });