### PR TITLE
fix: for October CMS release v1.0.455

### DIFF
--- a/classes/AuthHelperManager.php
+++ b/classes/AuthHelperManager.php
@@ -8,6 +8,7 @@ use Lovata\Buddies\Models\User;
 use Backend\Models\UserGroup;
 use Lovata\Buddies\Models\Throttle;
 use October\Rain\Auth\Manager as AuthManager;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 /**
  * Class AuthHelperManager
@@ -84,7 +85,7 @@ class AuthHelperManager extends AuthManager
      * @param User $obUser
      * @param bool $bRemember
      */
-    public function login($obUser, $bRemember = false)
+    public function login(Authenticatable $obUser, $bRemember = false)
     {
         $this->user = $obUser;
 


### PR DESCRIPTION
ERROR:

Declaration of Lovata\Buddies\Classes\AuthHelperManager::login($obUser, $bRemember = false) must be compatible with Illuminate\Contracts\Auth\StatefulGuard::login(Illuminate\Contracts\Auth\Authenticatable $user, $remember = false)